### PR TITLE
Update Imap.php

### DIFF
--- a/Imap.php
+++ b/Imap.php
@@ -120,7 +120,7 @@ class Imap {
     public function countUnreadMessages() {
         $result = imap_search($this->imap, 'UNSEEN');
         if($result===false)
-            return false;
+            return 0;
         return count($result);
     }
 
@@ -131,9 +131,12 @@ class Imap {
      * @param $withbody without body
      */
     public function getUnreadMessages($withbody=true){
+    	$emails = [];
         $result = imap_search($this->imap, 'UNSEEN');
-        foreach($result as $k=>$i){
-            $emails[]= $this->formatMessage($i, $withbody);
+        if($result){
+            foreach($result as $k=>$i){
+            	$emails[]= $this->formatMessage($i, $withbody);
+            }
         }
         return $emails;
     }


### PR DESCRIPTION
Fixed countUnreadMessages to return 0 instead of false
Fixed an issue in getUnreadMessages. If $result is false an "Invalid argument supplied for foreach()" php error happens. Now will check the $result first and then return an empty array if there's no unread messages.