### PR TITLE
Add ability to inherit from base IMAP class and override some properties

### DIFF
--- a/Imap.php
+++ b/Imap.php
@@ -13,17 +13,17 @@ class Imap {
     /**
      * imap connection
      */
-    private $imap = false;
+    protected $imap = false;
     
     /**
      * mailbox url string
      */
-    private $mailbox = "";
+    protected $mailbox = "";
     
     /**
      * currentfolder
      */
-    private $folder = "Inbox";
+    protected $folder = "Inbox";
     
     
     
@@ -456,7 +456,7 @@ class Imap {
     
     
     
-    // private helpers
+    // protected helpers
     
     
     /**
@@ -464,7 +464,7 @@ class Imap {
      *
      * @return trash folder name
      */
-    private function getTrash() {
+    protected function getTrash() {
         foreach($this->getFolders() as $folder) {
             if(strtolower($folder)==="trash" || strtolower($folder)==="papierkorb")
                 return $folder;
@@ -482,7 +482,7 @@ class Imap {
      *
      * @return sent folder name
      */
-    private function getSent() {
+    protected function getSent() {
         foreach($this->getFolders() as $folder) {
             if(strtolower($folder)==="sent" || strtolower($folder)==="gesendet")
                 return $folder;
@@ -501,7 +501,7 @@ class Imap {
      * @return header
      * @param $id of the message
      */
-    private function getMessageHeader($id) {
+    protected function getMessageHeader($id) {
         $count = $this->countMessages();
         for($i=1;$i<=$count;$i++) {
             $uid = imap_uid($this->imap, $i);
@@ -520,7 +520,7 @@ class Imap {
      * @return array
      * @param $attachments with name and size
      */
-    private function attachments2name($attachments) {
+    protected function attachments2name($attachments) {
         $names = array();
         foreach($attachments as $attachment) {
             $names[] = array(
@@ -538,7 +538,7 @@ class Imap {
      * @return string in format "Name <email@bla.de>"
      * @param $headerinfos the infos given by imap
      */
-    private function toAddress($headerinfos) {
+    protected function toAddress($headerinfos) {
         $email = "";
         $name = "";
         if(isset($headerinfos->mailbox) && isset($headerinfos->host)) {
@@ -564,7 +564,7 @@ class Imap {
      * @return array with strings (e.g. ["Name <email@bla.de>", "Name2 <email2@bla.de>"]
      * @param $addresses imap given addresses as array
      */
-    private function arrayToAddress($addresses) {
+    protected function arrayToAddress($addresses) {
         $addressesAsString = array();
         foreach($addresses as $address) {
             $addressesAsString[] = $this->toAddress($address);
@@ -579,7 +579,7 @@ class Imap {
      * @return string email body
      * @param $uid message id
      */
-    private function getBody($uid) {
+    protected function getBody($uid) {
         $body = $this->get_part($this->imap, $uid, "TEXT/HTML");
         $html = true;
         // if HTML body is empty, try getting text body
@@ -615,7 +615,7 @@ class Imap {
      * @param $uid message id
      * @param $mimetype
      */
-    private function get_part($imap, $uid, $mimetype, $structure = false, $partNumber = false) {
+    protected function get_part($imap, $uid, $mimetype, $structure = false, $partNumber = false) {
         if (!$structure) {
                $structure = imap_fetchstructure($imap, $uid, FT_UID);
         }
@@ -657,7 +657,7 @@ class Imap {
      * @return string mimetype
      * @param $structure
      */
-    private function get_mime_type($structure) {
+    protected function get_mime_type($structure) {
         $primaryMimetype = array("TEXT", "MULTIPART", "MESSAGE", "APPLICATION", "AUDIO", "IMAGE", "VIDEO", "OTHER");
      
         if ($structure->subtype) {
@@ -677,7 +677,7 @@ class Imap {
      * @param $part
      * @param $partNum
      */
-    private function getAttachments($imap, $mailNum, $part, $partNum) {
+    protected function getAttachments($imap, $mailNum, $part, $partNum) {
         $attachments = array();
      
         if (isset($part->parts)) {


### PR DESCRIPTION
In order to add new functions without impact on existing functionality would be good to convert private properties to protected.

This may be needed e.g. when developers want to add such method like search messages by criteria.