### PR TITLE
A few nice changes

### DIFF
--- a/ImapClient/ImapClient.php
+++ b/ImapClient/ImapClient.php
@@ -53,11 +53,14 @@ class ImapClient {
      * @param string $password
      * @param bool|false $encryption SSL or TLS
      */
-    public function __construct($mailbox, $username, $password, $encryption = false) {
+    public function __construct($mailbox, $username, $password, $encryption = false, $ignoreinvalidvert = false) {
         if (!function_exists('imap_open')) {
             throw new ImapClientException('Imap function not available');
         };
         $enc = '';
+        if($ignoreinvalidvert != null && $ignoreinvalidvert = true) {
+            $enc = '/novalidate-cert';
+        }
         if ($encryption != null && isset($encryption) && $encryption == 'ssl') {
             $enc = '/imap/ssl/novalidate-cert';
         }

--- a/ImapClient/ImapClient.php
+++ b/ImapClient/ImapClient.php
@@ -9,7 +9,7 @@ use SSilence\ImapClient\ImapClientException;
  *
  * @package    protocols
  * @copyright  Copyright (c) Tobias Zeising (http://www.aditu.de)
- * @license    GPLv3 (http://www.gnu.org/licenses/gpl-3.0.html)
+ * @license    Apache2.0 (https://www.apache.org/licenses/LICENSE-2.0)
  * @author     Tobias Zeising <tobias.zeising@aditu.de>
  */
 class ImapClient {
@@ -732,7 +732,7 @@ class ImapClient {
                 }
             }
 
-            // multipart 
+            // multipart
             if ($structure->type == 1) {
                 foreach ($structure->parts as $index => $subStruct) {
                     $prefix = "";

--- a/ImapClient/ImapClient.php
+++ b/ImapClient/ImapClient.php
@@ -67,7 +67,7 @@ class ImapClient {
         $this->mailbox = "{" . $mailbox . $enc . "}";
         $this->imap = @imap_open($this->mailbox, $username, $password);
         if ($this->imap === false) {
-            throw new ImapClientException('Not connect with '.$mailbox);
+            throw new ImapClientException('Failed to connect to: '.$mailbox);
         };
     }
 

--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    Copyright (C) 2016  SSilence
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    php-iamp-client  Copyright (C) 2016  SSilence
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
1) Updated license. It still had place holders
2) Fixed a VERY annoying grammar issue
3) Added the option for developed to ignore the imap_open Invalid Certificate Failure (Self-signed certificate or untrusted authority) message