### PR TITLE
Fix bad property in attachment detection

### DIFF
--- a/ImapClient/ImapClient.php
+++ b/ImapClient/ImapClient.php
@@ -957,10 +957,16 @@ class ImapClient
                 $partStruct = imap_bodystruct($this->imap, $mailNum, $partNum);
                 $reference = isset($partStruct->id) ? $partStruct->id : "";
                 $attachmentDetails = array();
-                if (isset($part->dparameters[0]))
-                {
+                $parameters = array();
+                if (isset($part->dparameters[0])) {
+                    $parameters = $part->dparameters[0];
+                } else if ($part->parameters[0]) {
+                    $parameters = $part->parameters[0];
+                }
+
+                if ($parameters) {
                     $attachmentDetails = array(
-                        "name"        => $part->dparameters[0]->value,
+                        "name"        => $parameters->value,
                         "partNum"     => $partNum,
                         "enc"         => @$partStruct->encoding,
                         "size"        => $part->bytes,


### PR DESCRIPTION
The "dparameters" is undefined for me (why ? I don't know). The good value is "parameters".
My patch checks if "dparameters" is set, if not, tests on "parameters".