### PR TITLE
Add headerDetail property for cc and bcc

### DIFF
--- a/ImapClient/IncomingMessage.php
+++ b/ImapClient/IncomingMessage.php
@@ -29,6 +29,10 @@ class IncomingMessage
 	 * Header of the message
 	 */
     public $header;
+    /**
+     * Detail header of the message
+     */
+    public $headerDetail;
 	/**
 	 * The message
 	 */
@@ -101,6 +105,7 @@ class IncomingMessage
     {
         $header = $this->imapFetchOverview();
         $this->header = $header[0];
+        $this->headerDetail = $this->imapHeaderInfo();
         $structure = $this->imapFetchstructure();
         $this->structure = $structure;
         if(isset($structure->parts)){
@@ -311,16 +316,15 @@ class IncomingMessage
         return imap_fetch_overview($this->imapStream, $sequence, $options);
     }
 
-	/**
-	 * This function is used to get the header info on a message.
-	 * Its return values can be found here: 
-	 * http://php.net/manual/en/function.imap-headerinfo.php#refsect1-function.imap-headerinfo-returnvalues
-	 * 
-	 * WARNING: This function may be moved to an internal call later
-	 *
-	 * @return object
-	 */
-	public function getHeaderInfo($msgnumber) {
-		return imap_headerinfo($this->imapStream, $msgnumber);
-	}
+    /*
+     * Imap Header Info
+     *
+     * Wrapper for http://php.net/manual/ru/function.imap-headerinfo.php
+     *
+     * @return object
+     */
+    private function imapHeaderInfo()
+    {
+        return imap_headerinfo($this->imapStream, $this->id);
+    }
 }

--- a/docs/guide-en/IncomingMessage.md
+++ b/docs/guide-en/IncomingMessage.md
@@ -1,8 +1,10 @@
 # Incoming Message
+
 ## Structure
-Incoming Message it is object(SSilence\ImapClient\IncomingMessage) has 5 basic properties
+Incoming Message it is object(SSilence\ImapClient\IncomingMessage) has 6 basic properties
 ```
 $imap->incomingMessage->header
+$imap->incomingMessage->headerDetail
 $imap->incomingMessage->message
 $imap->incomingMessage->attachment
 $imap->incomingMessage->section
@@ -51,6 +53,15 @@ Header properties typically looks like
 ```
 To get the subject of the message, use
 $imap->incomingMessage->header->subject
+
+### HeaderDetail properties
+HeaderDetail properties have more properties like this
+[imap_headerinfo](http://php.net/manual/ru/function.imap-headerinfo.php).
+If there is no property in the returned object, then it is not present in this letter.
+To get the CC or BCC of the message, use
+$imap->incomingMessage->headerDetail->cc
+or
+$imap->incomingMessage->headerDetail->bcc
 
 ### Message properties
 Message properties look like this:


### PR DESCRIPTION
Add headerDetail property for cc and bcc.
Usage
`
$imap->incomingMessage->headerDetail->cc
`
If there is no property in the returned object, then it is not present in this letter.