### PR TITLE
TypeBody and TypeAttachments might as well be static methods to save …

### DIFF
--- a/ImapClient/IncomingMessage.php
+++ b/ImapClient/IncomingMessage.php
@@ -59,7 +59,7 @@ class IncomingMessage
 	 */
     private $id;
 	/**
-	 * UID of the message 
+	 * UID of the message
 	 */
     private $uid;
 	/**
@@ -181,8 +181,7 @@ class IncomingMessage
      */
     private function getAttachment()
     {
-        $types = new TypeAttachments();
-        $types = $types->get();
+        $types = TypeAttachments::get();
         $attachments = [];
         foreach ($this->section as $section) {
             $obj = $this->getSection($section);
@@ -218,8 +217,7 @@ class IncomingMessage
      */
     private function getBody()
     {
-        $types = new TypeBody();
-        $types = $types->get();
+        $types = TypeBody::get();
         $objNew = new \stdClass();
         foreach ($this->section as $section) {
             $obj = $this->getSection($section);
@@ -354,11 +352,11 @@ class IncomingMessage
     {
         return imap_mime_header_decode($string);
     }
-    
+
     /*
      * Decodes and glues the title bar
      * http://php.net/manual/ru/function.imap-mime-header-decode.php
-     * 
+     *
      * @param string $string
      * @return string
      */

--- a/ImapClient/TypeAttachments.php
+++ b/ImapClient/TypeAttachments.php
@@ -23,27 +23,16 @@ class TypeAttachments
 	/**
 	 * Types of attachments
 	 */
-    public $types;
+    private static $types = ['JPEG', 'PNG', 'GIF', 'PDF', 'X-MPEG', 'MSWORD', 'OCTET-STREAM'];
 
-	/**
-	 * Class builder
-	 */  
-    public function __construct()
-    {
-        /*
-         * Allowed types attachments
-         */
-        $this->types = ['JPEG', 'PNG', 'GIF', 'PDF', 'X-MPEG', 'MSWORD', 'OCTET-STREAM'];
-    }
-
-    /**
+	 /**
      * Get the allowed types.
      *
      * @return array
      */
-    public function get()
+    public static function get()
     {
-        return $this->types;
+        return static::$types;
     }
 
 }

--- a/ImapClient/TypeBody.php
+++ b/ImapClient/TypeBody.php
@@ -20,31 +20,20 @@ namespace SSilence\ImapClient;
  */
 class TypeBody
 {
-	
-	/** 
-	 * Types of body's
-	 */
-    public $types;
 
 	/**
-	 * Called when a new instace is made
+	 * Types of body's
 	 */
-    public function __construct()
-    {
-        /*
-         * Allowed types message body
-         */
-        $this->types = ['PLAIN', 'HTML'];
-    }
+    private static $types = ['PLAIN', 'HTML'];
 
     /**
      * Get the allowed types.
      *
      * @return array
      */
-    public function get()
+    public static function get()
     {
-        return $this->types;
+        return static::types;
     }
 
 }


### PR DESCRIPTION
…time

### Is the pull request based off the lastest version?

Yes

### What features have you added?

Changed TypeBody and TypeAttachment methods to be static getters to save a few unnecessary lines of code

### What bugs did you fix?

No bugs

### Is your code valid PSR-2?

Yus

### Has anything in your pull request already been fixed?

N/A

### Anything else?

More to come, let me know if this one is cool with you

### Optional things below
[] Added your name to the credits
[] Add a update name below:

