### PR TITLE
fix maximum number of messages

### DIFF
--- a/ImapClient/ImapClient.php
+++ b/ImapClient/ImapClient.php
@@ -570,12 +570,16 @@ class ImapClient
             {
                 $ids = array_reverse($ids);
             }
-            $ids = array_chunk($ids, $number);
-            $ids = $ids[$start];
 
-            foreach ($ids as $id)
-            {
-                $emails[] = $this->getMessage($id);
+            if (count($ids) > $number) {
+                $ids = array_chunk($ids, $number);
+                $ids = $ids[$start];
+            }
+
+            if (isset($ids)) {
+                foreach ($ids as $id) {
+                    $emails[] = $this->getMessage($id);
+                }
             }
         }
         return $emails;


### PR DESCRIPTION
### Is the pull request based off the latest version?
Yes

### What bugs did you fix?
If `$number` is higher than the number of `$ids`, `$ids` becomes null.
e.g. $number = 30, $ids = 21 items.

### Is your code valid PSR-2?
Yes

### Have you properly documented your code?
Yes

### Has anything in your pull request already been fixed?
Don't know 