### PR TITLE
add getImap() function

### DIFF
--- a/ImapClient/ImapClient.php
+++ b/ImapClient/ImapClient.php
@@ -94,6 +94,16 @@ class ImapClient
         };
     }
 
+	/**
+	 * Get the imap resource
+	 *
+	 * @return resource
+	 */
+	public function getImap()
+    {
+    	return $this->imap;
+    }
+
     /**
      * Set connection to advanced
      *


### PR DESCRIPTION
### Is the pull request based off the lastest version?
Yes.

### What features have you added?
Added method getImap() to be able to use some imap functions that haven't wrappers in this client. For example imap_fetchheader(). 

In my case I want to check get all multiple email form 'to' field, that seems impossible by imap_headerinfo() according to comments [1](http://php.net/manual/ru/function.imap-headerinfo.php#120797) and [2](http://php.net/manual/ru/function.imap-headerinfo.php#98809)

### What bugs did you fix?
Not fix any bugs.

### Is your code valid PSR-2?
Yes

### Have you properly documented your code?
Yes

### Has anything in your pull request already been fixed?
No

### Anything else?
No