### PR TITLE
Fix Docs

### DIFF
--- a/docs/connecting.html
+++ b/docs/connecting.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/errordb.html
+++ b/docs/errordb.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/gettingstarted.html
+++ b/docs/gettingstarted.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/guide/incomingmessage.md
+++ b/docs/guide/incomingmessage.md
@@ -56,7 +56,7 @@ The header properties typically look like this:
 To get the subject of the message, use
 $imap->incomingMessage->header->subject
 
-This object also contains the id and the uid of the current message according to https://php.net/manual/ru/function.imap-fetch-overview.php:
+This object also contains the id and the uid of the current message according to https://php.net/manual/en/function.imap-fetch-overview.php:
 ```php
 # id
     $imap->incomingMessage->header->msgno;
@@ -68,7 +68,7 @@ To get the CC or BCC use the property
 ```php
 $imap->incomingMessage->header->details
 ```
-Header details properties have more properties like this [imap_headerinfo](https://php.net/manual/ru/function.imap-headerinfo.php).
+Header details properties have more properties like this [imap_headerinfo](https://php.net/manual/en/function.imap-headerinfo.php).
 If there is no property in the returned object, then it is not present in this email.
 To get the CC or BCC of the message, use
 ```php

--- a/docs/guide/incomingmessage.md
+++ b/docs/guide/incomingmessage.md
@@ -56,7 +56,7 @@ The header properties typically look like this:
 To get the subject of the message, use
 $imap->incomingMessage->header->subject
 
-This object also contains the id and the uid of the current message according to http://php.net/manual/ru/function.imap-fetch-overview.php:
+This object also contains the id and the uid of the current message according to https://php.net/manual/ru/function.imap-fetch-overview.php:
 ```php
 # id
     $imap->incomingMessage->header->msgno;
@@ -68,7 +68,7 @@ To get the CC or BCC use the property
 ```php
 $imap->incomingMessage->header->details
 ```
-Header details properties have more properties like this [imap_headerinfo](http://php.net/manual/ru/function.imap-headerinfo.php).
+Header details properties have more properties like this [imap_headerinfo](https://php.net/manual/ru/function.imap-headerinfo.php).
 If there is no property in the returned object, then it is not present in this email.
 To get the CC or BCC of the message, use
 ```php

--- a/docs/guide/methods.md
+++ b/docs/guide/methods.md
@@ -12,8 +12,8 @@ The following methods are currently available.
 * ``getQuota($user)`` Retrieve the quota level settings, and usage statics per mailbox.
 * ``getQuotaRoot($user)`` Retrieve the quota level settings, and usage statics per mailbox.
 * ``getAllEmailAddresses()`` returns all email addresses of all emails (for auto suggestion list).
-* ``getMailboxStatistics()`` returns statistics, see [imap_mailboxmsginfo](http://php.net/manual/en/function.imap-mailboxmsginfo.php).
-* ``getHeaderInfo($msgNumber)`` Get the header info via the message number. http://php.net/manual/en/function.imap-headerinfo.php#refsect1-function.imap-headerinfo-returnvalues
+* ``getMailboxStatistics()`` returns statistics, see [imap_mailboxmsginfo](https://php.net/manual/en/function.imap-mailboxmsginfo.php).
+* ``getHeaderInfo($msgNumber)`` Get the header info via the message number. https://php.net/manual/en/function.imap-headerinfo.php#refsect1-function.imap-headerinfo-returnvalues
 * ``getMessagesByCriteria($criteria, $number, $start, $order)`` Get messages by criteria like 'FROM uncle'.
 * ``getBriefInfoMessages()`` Get a short information about the messages in the current folder.
 * ``getSection($id, $section)`` Get the section of the specified message.

--- a/docs/incomingmessage.html
+++ b/docs/incomingmessage.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/installing.html
+++ b/docs/installing.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/methods.html
+++ b/docs/methods.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/outgoing.html
+++ b/docs/outgoing.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -9,7 +9,7 @@
   <title>php-imap-client</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -34,23 +34,23 @@
     <div class='left'>
       <h1>php-imap-client</h1>
       <ul>
-        <li><a href='http://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/gettingstarted.html'>Getting started</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client'>View on GitHub</a></li>
         <li><a href='https://github.com/SSilence/php-imap-client/issues'>Issues</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
-        <li><a href='http://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/contributing.html'>Contributing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/connecting.html'>Connecting</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/errordb.html'>Error database</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/incomingmessage.html'>Incoming message</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/installing.html'>Installing</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/methods.html'>Methods</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/usage.html'>Usage</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/examples.html'>Examples</a></li>
+        <li><a href='https://ssilence.github.io/php-imap-client/outgoing.html'>Outgoing</a></li>
       </ul>
     </div>
     <div class='right'>
-      <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=SSilence&amp;repo=php-imap-client&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 


### PR DESCRIPTION
- Links to `php.net` now go to `en` version instead of `ru`
- The docs were throwing exceptions in modern up to date browsers because it was detecting possible downgrade attacks (trying to load http scripts on https connections).