### PR TITLE
It is not possible to check the dynamic property "structure" using pr…

### DIFF
--- a/ImapClient/IncomingMessage.php
+++ b/ImapClient/IncomingMessage.php
@@ -361,7 +361,7 @@ class IncomingMessage
         $subType = new SubtypeBody();
         foreach ($this->getSections(self::SECTION_BODY) as $section) {
             $obj = $this->getSection($section, array('class' => $subType));
-            if(!is_object($obj) || !property_exists($obj, 'structure')) {
+            if(!is_object($obj) || !$obj->__get('structure')) {
                 continue;
             }
             $subtype = strtolower($obj->__get('structure')->subtype);


### PR DESCRIPTION
…operty_exists()

Check instead of there is a value using the __get() method.

### Is the pull request based off the lastest version?
yes
### What features have you added?
none
### What bugs did you fix?
problem where message body text is always null
### Is your code valid PSR-2?
yes
### Have you properly documented your code?
nothing to document
### Has anything in your pull request already been fixed?
no
### Anything else?
no
### Optional things below
[] Added your name to the credits
