### PR TITLE
Added 'XML' to the array of static types for attachments.   If an att…

### DIFF
--- a/ImapClient/TypeAttachments.php
+++ b/ImapClient/TypeAttachments.php
@@ -19,7 +19,7 @@ class TypeAttachments
      *
      * @var array
      */
-    private static $types = array('JPEG', 'PNG', 'GIF', 'PDF', 'X-MPEG', 'MSWORD', 'OCTET-STREAM', 'TXT', 'TEXT', 'MWORD', 'ZIP', 'MPEG', 'DBASE', 'ACROBAT', 'POWERPOINT', 'BMP', 'BITMAP');
+    private static $types = array('JPEG', 'PNG', 'GIF', 'PDF', 'X-MPEG', 'MSWORD', 'OCTET-STREAM', 'TXT', 'TEXT', 'XML', 'MWORD', 'ZIP', 'MPEG', 'DBASE', 'ACROBAT', 'POWERPOINT', 'BMP', 'BITMAP');
 
     /**
      * Get the allowed types.


### PR DESCRIPTION
…achment was on an email of content-type text/xml as opposed to application/octet-stream, it was being left out of the attachments of the message

### Is the pull request based off the lastest version?
yes

### What features have you added?
none

### What bugs did you fix?
Added 'XML' as an attachment type so text/xml attachments are included in attachments

### Is your code valid PSR-2?
yes

### Have you properly documented your code?
yes

### Has anything in your pull request already been fixed?
no

### Anything else?
no

### Optional things below
[] Added your name to the credits
